### PR TITLE
Add react-datepicker

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,7 @@
     "@reach/router": "^1.3.3",
     "jwt-decode": "^2.2.0",
     "react": "^16.13.1",
+    "react-datepicker": "^2.14.1",
     "react-dom": "^16.13.1"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -35,6 +35,7 @@
     "@material-ui/core": "^4.9.11",
     "@material-ui/icons": "^4.9.1",
     "@reach/router": "^1.3.3",
+    "date-fns": "^2.13.0",
     "jwt-decode": "^2.2.0",
     "react": "^16.13.1",
     "react-datepicker": "^2.14.1",

--- a/app/src/controller/FormController.js
+++ b/app/src/controller/FormController.js
@@ -18,7 +18,7 @@ type FormControls = {|
   isSubmitting: boolean
 |};
 export type $FormController = () => FormControls;
-type FormTarget = { target: HTMLInputElement };
+type FormTarget = { target: { name: string, value: string }};
 export type FormValues = {
   [string]: string
 };

--- a/app/src/util/util.js
+++ b/app/src/util/util.js
@@ -11,10 +11,6 @@ export const cls = (...classes:Array<?(string | boolean)>):string => {
 
 export const merge = (a:Object, b:Object):Object => Object.assign({}, a, b);
 
-export const localISODate = () => {
-  const tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
-  return (new Date(Date.now() - tzoffset)).toISOString().slice(0, -1);
-};
 
 export const delay = (millis:number):Promise<void> => 
   new Promise((resolve) => {

--- a/app/src/view/ControllableForm.js
+++ b/app/src/view/ControllableForm.js
@@ -15,8 +15,6 @@ import ProgressButton from './ProgressButton';
 import { nilControls } from '../controller/FormController';
 import DatePicker from './DatePicker';
 
-import 'react-datepicker/dist/react-datepicker.css';
-
 import type { $FormController } from '../controller/FormController';
 
 type FormField = {|

--- a/app/src/view/ControllableForm.js
+++ b/app/src/view/ControllableForm.js
@@ -12,6 +12,7 @@ import {
   Box 
 } from '@material-ui/core';
 import DatePicker from 'react-datepicker';
+import { formatISO, parseISO } from 'date-fns';
 import ProgressButton from './ProgressButton';
 import { nilControls } from '../controller/FormController';
 
@@ -48,9 +49,10 @@ const ControllableForm = ({ submitLabel, fields, controller }: P) => {
       {fields.map(f => {
         if (f.type === 'datetime-local') {
           const onChangeWrapper = (value) => {
-            const event = {"target": {"name": f.name, "value": value}};
+            const event = {"target": {"name": f.name, "value": formatISO(value)}};
             onChange(event);
           }
+          const selected = values[f.name] ? parseISO(values[f.name]) : null;
           return (
             <DatePicker
               key={f.name}
@@ -61,6 +63,7 @@ const ControllableForm = ({ submitLabel, fields, controller }: P) => {
               timeCaption="time"
               dateFormat="MMMM d, yyyy h:mm aa"
               placeholderText={f.label}
+              selected={selected}
             />
           )
         } else {

--- a/app/src/view/ControllableForm.js
+++ b/app/src/view/ControllableForm.js
@@ -51,6 +51,7 @@ const ControllableForm = ({ submitLabel, fields, controller }: P) => {
             <DatePicker
               key={f.name}
               name={f.name}
+              label={f.label}
               onChange={onChange}
               selected={values[f.name]}
             />

--- a/app/src/view/ControllableForm.js
+++ b/app/src/view/ControllableForm.js
@@ -11,10 +11,9 @@ import {
   Typography,
   Box 
 } from '@material-ui/core';
-import DatePicker from 'react-datepicker';
-import { formatISO, parseISO } from 'date-fns';
 import ProgressButton from './ProgressButton';
 import { nilControls } from '../controller/FormController';
+import DatePicker from './DatePicker';
 
 import 'react-datepicker/dist/react-datepicker.css';
 
@@ -48,22 +47,12 @@ const ControllableForm = ({ submitLabel, fields, controller }: P) => {
     <form onSubmit={onSubmit}>
       {fields.map(f => {
         if (f.type === 'datetime-local') {
-          const onChangeWrapper = (value) => {
-            const event = {"target": {"name": f.name, "value": formatISO(value)}};
-            onChange(event);
-          }
-          const selected = values[f.name] ? parseISO(values[f.name]) : null;
           return (
             <DatePicker
               key={f.name}
-              onChange={onChangeWrapper}
-              showTimeSelect
-              timeFormat="HH:mm"
-              timeIntervals={15}
-              timeCaption="time"
-              dateFormat="MMMM d, yyyy h:mm aa"
-              placeholderText={f.label}
-              selected={selected}
+              name={f.name}
+              onChange={onChange}
+              selected={values[f.name]}
             />
           )
         } else {

--- a/app/src/view/ControllableForm.js
+++ b/app/src/view/ControllableForm.js
@@ -11,8 +11,11 @@ import {
   Typography,
   Box 
 } from '@material-ui/core';
+import DatePicker from 'react-datepicker';
 import ProgressButton from './ProgressButton';
 import { nilControls } from '../controller/FormController';
+
+import 'react-datepicker/dist/react-datepicker.css';
 
 import type { $FormController } from '../controller/FormController';
 
@@ -42,24 +45,43 @@ const ControllableForm = ({ submitLabel, fields, controller }: P) => {
   } = controller ? controller() : nilControls;
   return (
     <form onSubmit={onSubmit}>
-      {fields.map(f => (
-        <TextField
-          key={f.name}
-          variant="outlined"
-          margin="normal"
-          required={f.required}
-          fullWidth
-          name={f.name}
-          label={f.label}
-          type={f.type}
-          value={values[f.name] || ''}
-          onChange={onChange}
-          autoComplete={f.autoComplete}
-          error={!!errors[f.name]}
-          helperText={errors[f.name]}
-          inputProps={f.pattern && { pattern: f.pattern[0], title: f.pattern[1] }}
-        />
-      ))}
+      {fields.map(f => {
+        if (f.type === 'datetime-local') {
+          const onChangeWrapper = (value) => {
+            const event = {"target": {"name": f.name, "value": value}};
+            onChange(event);
+          }
+          return (
+            <DatePicker
+              key={f.name}
+              onChange={onChangeWrapper}
+              showTimeSelect
+              timeFormat="HH:mm"
+              timeIntervals={15}
+              timeCaption="time"
+              dateFormat="MMMM d, yyyy h:mm aa"
+              placeholderText={f.label}
+            />
+          )
+        } else {
+          return (
+            <TextField
+              key={f.name}
+              variant="outlined"
+              margin="normal"
+              required={f.required}
+              fullWidth
+              name={f.name}
+              label={f.label}
+              type={f.type}
+              value={values[f.name] || ''}
+              onChange={onChange}
+              autoComplete={f.autoComplete}
+              error={!!errors[f.name]}
+              helperText={errors[f.name]}
+              inputProps={f.pattern && { pattern: f.pattern[0], title: f.pattern[1] }}
+            />
+          )}})}
       { responseCode === 401 && <Typography align="center" color="error">Incorrect username or password</Typography> }
       <Box mt={4}>
         <ProgressButton

--- a/app/src/view/CreateEvent.js
+++ b/app/src/view/CreateEvent.js
@@ -12,7 +12,7 @@ import EventForm from './EventForm';
 import FormController from '../controller/FormController';
 import { Link } from '../controller/RouterLink';
 import { navigate } from '@reach/router';
-import { localISODate } from '../util/util';
+import { addHours, formatISO, startOfHour } from 'date-fns';
 import { 
   Container,
   Card,
@@ -31,8 +31,8 @@ const CreateEvent = () => {
       navigate('/home');
     },
     {
-      start: localISODate(),
-      end: localISODate()
+      start: formatISO(addHours(startOfHour(Date.now()), 2)),
+      end: formatISO(addHours(startOfHour(Date.now()), 5)),
     }
   );
   return (

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -145,6 +145,7 @@ const DatePicker = ({name, onChange, selected, label}: P) => {
         key={name}
         className={styles.datepicker}
         popperContainer={Portal}
+        minDate={new Date()}
         showTimeSelect
         timeFormat="h:mm aa"
         timeIntervals={15}

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -11,6 +11,8 @@ import ReactDatePicker from 'react-datepicker';
 import { makeStyles } from '@material-ui/core/styles';
 import { formatISO, parseISO } from 'date-fns';
 
+import 'react-datepicker/dist/react-datepicker.css';
+
 type FormTarget = { target: { name: string, value: string }};
 type P = {
   name: string,

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -6,6 +6,7 @@
  */
 
 import React from 'react';
+import { createPortal } from 'react-dom';
 import ReactDatePicker from 'react-datepicker';
 import { makeStyles } from '@material-ui/core/styles';
 import { formatISO, parseISO } from 'date-fns';
@@ -81,6 +82,26 @@ const useStyles = makeStyles((theme) => {
   };
 });
 
+const Portal = ({children}) => {
+  const portalRoot = document.getElementById("portal");
+  const el = document.createElement("div");
+
+  if (!portalRoot) {
+    console.error("No portal root found");
+    return;
+  }
+
+  React.useEffect(() => {
+    portalRoot.appendChild(el);
+    return () => {
+      portalRoot.removeChild(el);
+      return;
+    }
+  }, [el, portalRoot]);
+
+  return createPortal(children, el);
+};
+
 const DatePicker = ({name, onChange, selected, label}: P) => {
   const onChangeWrapper = (value) => {
     const event = {"target": {"name": name, "value": formatISO(value)}};
@@ -92,6 +113,7 @@ const DatePicker = ({name, onChange, selected, label}: P) => {
       <ReactDatePicker
         key={name}
         className={styles.datepicker}
+        popperContainer={Portal}
         showTimeSelect
         timeFormat="h:mm aa"
         timeIntervals={15}

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -124,10 +124,7 @@ const Portal = ({children}) => {
 
   React.useEffect(() => {
     portalRoot.appendChild(el);
-    return () => {
-      portalRoot.removeChild(el);
-      return;
-    }
+    return () => { portalRoot.removeChild(el); };
   }, [el, portalRoot]);
 
   return createPortal(children, el);

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ReactDatePicker from 'react-datepicker';
+import { makeStyles } from '@material-ui/core/styles';
 import { formatISO, parseISO } from 'date-fns';
 
 type FormTarget = { target: { name: string, value: string }};
@@ -14,24 +15,89 @@ type P = {
   name: string,
   onChange: FormTarget => void,
   selected: string,
+  label: string,
 };
 
-const DatePicker = ({name, onChange, selected}: P) => {
+const useStyles = makeStyles(theme => ({
+  label: {
+    position: 'relative',
+    display: 'inline-block',
+    paddingTop: '6px',
+    marginTop: '16px',
+    marginBottom: '8px',
+  },
+  datepicker: {
+    backgroundColor: theme.palette.background.paper,
+    borderColor: 'rgba(255, 255, 255, 0.23)',
+    borderTopColor: 'transparent',
+    border: 'solid 1px',
+    borderRadius: theme.shape.borderRadius,
+    padding: '18.5px 14px',
+    color: theme.palette.text.primary,
+    fontSize: theme.typography.fontSize,
+    lineHeight: '18px',
+    '&:hover': {
+      borderColor: theme.palette.text.primary,
+      borderTopColor: 'transparent',
+    },
+  },
+  span: {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    display: 'flex',
+    width: '100%',
+    fontSize: '10px',
+    lineHeight: '15px',
+    '&:before,&:after': {
+      content: '""',
+      display: 'block',
+      boxSizing: 'border-box',
+      marginTop: '6px',
+      borderTop: 'solid 1px',
+      borderColor: 'rgba(255, 255, 255, 0.23)',
+      minWidth: '10px',
+      height: '8px',
+    },
+    '&:hover::before,&:hover::after': {
+      borderColor: theme.palette.text.primary,
+    },
+    '&:before': {
+      marginRight: '4px',
+      borderLeft: 'solid 1px transparent',
+      borderRadius: '4px 0',
+    },
+    '&:after': {
+      flexGrow: '1',
+      marginLeft: '4px',
+      borderRight: 'solid 1px transparent',
+      borderRadius: '0 4px 4px 0',
+      height: '57px',
+    },
+  },
+}));
+
+const DatePicker = ({name, onChange, selected, label}: P) => {
   const onChangeWrapper = (value) => {
     const event = {"target": {"name": name, "value": formatISO(value)}};
     onChange(event);
   }
+  const styles = useStyles();
   return (
-    <ReactDatePicker
-      key={name}
-      showTimeSelect
-      timeFormat="h:mm aa"
-      timeIntervals={15}
-      timeCaption="time"
-      dateFormat="MMMM d, yyyy h:mm aa"
-      onChange={onChangeWrapper}
-      selected={selected ? parseISO(selected) : null}
-    />
+    <label className={styles.label}>
+      <ReactDatePicker
+        key={name}
+        className={styles.datepicker}
+        showTimeSelect
+        timeFormat="h:mm aa"
+        timeIntervals={15}
+        timeCaption="time"
+        dateFormat="MMMM d, yyyy h:mm aa"
+        onChange={onChangeWrapper}
+        selected={selected ? parseISO(selected) : null}
+      />
+      <span className={styles.span}>{label}</span>
+    </label>
   )};
 
 export default DatePicker;

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -14,12 +14,12 @@ import { formatISO, parseISO } from 'date-fns';
 import 'react-datepicker/dist/react-datepicker.css';
 
 type FormTarget = { target: { name: string, value: string }};
-type P = {
+type P = {|
   name: string,
   onChange: FormTarget => void,
   selected: string,
   label: string,
-};
+|};
 
 const useStyles = makeStyles((theme) => {
   const borderColor = theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -1,0 +1,37 @@
+/**
+ * Date picker, wraps ReactDatePicker for now
+ * @author scjody
+ * @since May 2020
+ * @flow
+ */
+
+import React from 'react';
+import ReactDatePicker from 'react-datepicker';
+import { formatISO, parseISO } from 'date-fns';
+
+type FormTarget = { target: { name: string, value: string }};
+type P = {
+  name: string,
+  onChange: FormTarget => void,
+  selected: string,
+};
+
+const DatePicker = ({name, onChange, selected}: P) => {
+  const onChangeWrapper = (value) => {
+    const event = {"target": {"name": name, "value": formatISO(value)}};
+    onChange(event);
+  }
+  return (
+    <ReactDatePicker
+      key={name}
+      showTimeSelect
+      timeFormat="h:mm aa"
+      timeIntervals={15}
+      timeCaption="time"
+      dateFormat="MMMM d, yyyy h:mm aa"
+      onChange={onChangeWrapper}
+      selected={selected ? parseISO(selected) : null}
+    />
+  )};
+
+export default DatePicker;

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -81,12 +81,36 @@ const useStyles = makeStyles((theme) => {
         height: '57px',
       },
     },
+    '@global': {
+      '#datepickers .react-datepicker__header, #datepickers .react-datepicker__current-month, #datepickers .react-datepicker__day-name, #datepickers .react-datepicker-time__header': {
+        backgroundColor: theme.palette.background.default,
+        color: theme.palette.text.primary,
+        borderColor: borderColor,
+      },
+      '#datepickers .react-datepicker, #datepickers .react-datepicker__day, #datepickers .react-datepicker__time, #datepickers .react-datepicker__time-container': {
+        backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
+        borderColor: borderColor,
+      },
+      '#datepickers .react-datepicker__time-list-item': {
+        height: 'auto',
+        padding: '7px 10px',
+      },
+      '#datepickers .react-datepicker__day--selected, #datepickers .react-datepicker__time-list-item--selected': {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
+      },
+      '#datepickers .react-datepicker__day:hover, #datepickers .react-datepicker__time-list-item:hover': {
+        backgroundColor: theme.palette.background.default,
+      },
+    },
   };
 });
 
 const Portal = ({children}) => {
   const portalRoot = document.getElementById("portal");
   const el = document.createElement("div");
+  el.id = "datepickers";
 
   if (!portalRoot) {
     console.error("No portal root found");

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -18,64 +18,68 @@ type P = {
   label: string,
 };
 
-const useStyles = makeStyles(theme => ({
-  label: {
-    position: 'relative',
-    display: 'inline-block',
-    paddingTop: '6px',
-    marginTop: '16px',
-    marginBottom: '8px',
-  },
-  datepicker: {
-    backgroundColor: theme.palette.background.paper,
-    borderColor: 'rgba(255, 255, 255, 0.23)',
-    borderTopColor: 'transparent',
-    border: 'solid 1px',
-    borderRadius: theme.shape.borderRadius,
-    padding: '18.5px 14px',
-    color: theme.palette.text.primary,
-    fontSize: theme.typography.fontSize,
-    lineHeight: '18px',
-    '&:hover': {
-      borderColor: theme.palette.text.primary,
+const useStyles = makeStyles((theme) => {
+  const borderColor = theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+
+  return {
+    label: {
+      position: 'relative',
+      display: 'inline-block',
+      paddingTop: '6px',
+      marginTop: '16px',
+      marginBottom: '8px',
+    },
+    datepicker: {
+      backgroundColor: theme.palette.background.paper,
+      borderColor: borderColor,
       borderTopColor: 'transparent',
+      border: 'solid 1px',
+      borderRadius: theme.shape.borderRadius,
+      padding: '18.5px 14px',
+      color: theme.palette.text.primary,
+      fontSize: theme.typography.fontSize,
+      lineHeight: '18px',
+      '&:hover': {
+        borderColor: theme.palette.text.primary,
+        borderTopColor: 'transparent',
+      },
     },
-  },
-  span: {
-    position: 'absolute',
-    top: '0',
-    left: '0',
-    display: 'flex',
-    width: '100%',
-    fontSize: '10px',
-    lineHeight: '15px',
-    '&:before,&:after': {
-      content: '""',
-      display: 'block',
-      boxSizing: 'border-box',
-      marginTop: '6px',
-      borderTop: 'solid 1px',
-      borderColor: 'rgba(255, 255, 255, 0.23)',
-      minWidth: '10px',
-      height: '8px',
+    span: {
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      display: 'flex',
+      width: '100%',
+      fontSize: '10px',
+      lineHeight: '15px',
+      '&:before,&:after': {
+        content: '""',
+        display: 'block',
+        boxSizing: 'border-box',
+        marginTop: '6px',
+        borderTop: 'solid 1px',
+        borderColor: borderColor,
+        minWidth: '10px',
+        height: '8px',
+      },
+      '&:hover::before,&:hover::after': {
+        borderColor: theme.palette.text.primary,
+      },
+      '&:before': {
+        marginRight: '4px',
+        borderLeft: 'solid 1px transparent',
+        borderRadius: '4px 0',
+      },
+      '&:after': {
+        flexGrow: '1',
+        marginLeft: '4px',
+        borderRight: 'solid 1px transparent',
+        borderRadius: '0 4px 4px 0',
+        height: '57px',
+      },
     },
-    '&:hover::before,&:hover::after': {
-      borderColor: theme.palette.text.primary,
-    },
-    '&:before': {
-      marginRight: '4px',
-      borderLeft: 'solid 1px transparent',
-      borderRadius: '4px 0',
-    },
-    '&:after': {
-      flexGrow: '1',
-      marginLeft: '4px',
-      borderRight: 'solid 1px transparent',
-      borderRadius: '0 4px 4px 0',
-      height: '57px',
-    },
-  },
-}));
+  };
+});
 
 const DatePicker = ({name, onChange, selected, label}: P) => {
   const onChangeWrapper = (value) => {

--- a/app/src/view/DatePicker.js
+++ b/app/src/view/DatePicker.js
@@ -31,6 +31,10 @@ const useStyles = makeStyles((theme) => {
       paddingTop: '6px',
       marginTop: '16px',
       marginBottom: '8px',
+      width: '100%',
+      '& .react-datepicker-wrapper': {
+        display: 'inline',
+      },
     },
     datepicker: {
       backgroundColor: theme.palette.background.paper,
@@ -42,6 +46,7 @@ const useStyles = makeStyles((theme) => {
       color: theme.palette.text.primary,
       fontSize: theme.typography.fontSize,
       lineHeight: '18px',
+      width: '100%',
       '&:hover': {
         borderColor: theme.palette.text.primary,
         borderTopColor: 'transparent',

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -14,5 +14,6 @@
   <body>
     <noscript>Javascript required. Sorry 😿</noscript>
     <div id="app"></div>
+    <div id="portal"></div>
   </body>
 </html>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1899,6 +1899,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -2143,7 +2148,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@0.3.0:
+create-react-context@0.3.0, create-react-context@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
   integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
@@ -2236,6 +2241,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+date-fns@^2.0.1:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.12.0.tgz#01754c8a2f3368fc1119cf4625c3dad8c1845ee6"
+  integrity sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2267,7 +2277,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-deep-equal@^1.0.1:
+deep-equal@^1.0.1, deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -4954,7 +4964,7 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-popper.js@^1.16.1-lts:
+popper.js@^1.14.4, popper.js@^1.16.1-lts:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -5191,6 +5201,17 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-datepicker@^2.14.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.14.1.tgz#83463beb85235a575475955f554290a95f89c65b"
+  integrity sha512-8eWHvrjXfKVkt5rERXC6/c/eEdcE2stIsl+QmTO5Efgpacf8MOCyVpBisJLVLDYjVlENczhOcRlIzvraODHKxA==
+  dependencies:
+    classnames "^2.2.6"
+    date-fns "^2.0.1"
+    prop-types "^15.7.2"
+    react-onclickoutside "^6.9.0"
+    react-popper "^1.3.4"
+
 react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -5210,6 +5231,24 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-onclickoutside@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"
+  integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
+
+react-popper@^1.3.4:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
+  integrity sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "^0.3.0"
+    deep-equal "^1.1.1"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-transition-group@^4.3.0:
   version "4.3.0"
@@ -6172,6 +6211,11 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -6347,7 +6391,7 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-warning@^4.0.3:
+warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2246,6 +2246,11 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.12.0.tgz#01754c8a2f3368fc1119cf4625c3dad8c1845ee6"
   integrity sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw==
 
+date-fns@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.13.0.tgz#d7b8a0a2d392e8d88a8024d0a46b980bbfdbd708"
+  integrity sha512-xm0c61mevGF7f0XpCGtDTGpzEFC/1fpLXHbmFpxZZQJuvByIK2ozm6cSYuU+nxFYOPh2EuCfzUwlTEFwKG+h5w==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
This PR adds react-datepicker to improve date selection and to fix the timezone issue with the default date input field. I consider it "good enough for now" but not perfect - a custom date picker (maybe based on https://material-ui-pickers.dev/) would let us build something even nicer.

Styling works and is based on the material-ui theme. One quirk is that the picker pops up either below the entry field (for the start time) or above it (for the end time)  because there isn't enough room below it. I imagine there will be more components (like a description) below the date fields soon enough and the problem will go away then.

![Screen Shot 2020-05-22 at 13 37 21](https://user-images.githubusercontent.com/1136329/82694825-f8386f00-9c31-11ea-9f97-c46550f0b004.png)

I have a couple of concerns about how I ended up doing things and I'll put them as review comments. Review comments are extremely welcome; I haven't done any serious frontend or JS work in several years and a lot of things (flow, JSS, React without classes) are new to me.